### PR TITLE
small systems patch

### DIFF
--- a/scripts/screens/ProfileScreen.py
+++ b/scripts/screens/ProfileScreen.py
@@ -1756,18 +1756,6 @@ class ProfileScreen(Screens):
         
         # gather a list of all the conditions and info needed.
         all_illness_injuries = []
-        '''
-        if self.the_cat.is_plural():
-            alter_info = []
-            for alter in self.the_cat.alters:
-                print(alter)
-                print(alter['name'])
-                alter_info.extend(['alter', 'test'])
-            all_illness_injuries.extend(alter_info)
-        for i in all_illness_injuries:
-            print(i)
-            '''
-        
                 
         all_illness_injuries.extend([(i, self.get_condition_details(i)) for i in self.the_cat.permanent_condition if
                                 not (self.the_cat.permanent_condition[i]['born_with'] and self.the_cat.permanent_condition[i]["moons_until"] != -2)])
@@ -1918,7 +1906,10 @@ class ProfileScreen(Screens):
         if name in self.the_cat.permanent_condition:
             # display if the cat was born with it
             if self.the_cat.permanent_condition[name]["born_with"] is True:
-                text_list.append(f"born with this condition")
+                if name not in ["shattered soul", "budding spirit"]:
+                    text_list.append(f"born with this condition")
+                else:
+                    text_list.append(f"split in early kithood")
             else:
                 # moons with the condition if not born with condition
                 moons_with = game.clan.age - self.the_cat.permanent_condition[name]["moon_start"]


### PR DESCRIPTION
alters will now save their origins and splits. for alters prior to the update, their origin will automatically be set to "core" for the sake of simplicity. cats with did/osdd will no longer display "born with this condition" and will instead display "split in early kithood"